### PR TITLE
fix(landing): correct CSS class for white provider icons

### DIFF
--- a/docs-site/assets/css/custom.css
+++ b/docs-site/assets/css/custom.css
@@ -1781,7 +1781,7 @@ div[class*="mt-6"] > a,
   opacity: 0.9;
 }
 
-.provider-logo-svg {
+.provider-logo {
   filter: brightness(0) saturate(100%) invert(95%) sepia(0%) saturate(0%) hue-rotate(93deg) brightness(103%) contrast(103%);
 }
 


### PR DESCRIPTION
The CSS filter was targeting .provider-logo-svg but the HTML uses .provider-logo class. Fixed the selector so icons render white.