### PR TITLE
test: expand coverage for di, health, keypool, and vinfo packages

### DIFF
--- a/internal/di/export_test.go
+++ b/internal/di/export_test.go
@@ -1,6 +1,7 @@
 package di
 
 import (
+	"net/http"
 	"sync/atomic"
 
 	"github.com/omarluq/cc-relay/internal/cache"
@@ -239,8 +240,10 @@ func NewConfigServiceWithNilWatcher(cfg *config.Config) *ConfigService {
 }
 
 // NewProviderMapServiceWithConfigService creates a ProviderMapService with a specific ConfigService.
+// Does not initialize the atomic data pointer - callers must call StoreProviderMapData to set data,
+// or rely on the legacy Providers field fallback.
 func NewProviderMapServiceWithConfigService(cfgSvc *ConfigService) *ProviderMapService {
-	svc := &ProviderMapService{
+	return &ProviderMapService{
 		data:            atomic.Pointer[providerMapData]{},
 		cfgSvc:          cfgSvc,
 		PrimaryProvider: nil,
@@ -248,13 +251,6 @@ func NewProviderMapServiceWithConfigService(cfgSvc *ConfigService) *ProviderMapS
 		PrimaryKey:      "",
 		AllProviders:    nil,
 	}
-	svc.data.Store(&providerMapData{
-		PrimaryProvider: nil,
-		Providers:       nil,
-		PrimaryKey:      "",
-		AllProviders:    nil,
-	})
-	return svc
 }
 
 // NewProviderInfoService creates a ProviderInfoService with all dependencies.
@@ -290,4 +286,63 @@ func NewHealthTrackerServiceWithTracker(tracker *health.Tracker) *HealthTrackerS
 		cfgSvc:  nil,
 		logger:  nil,
 	}
+}
+
+// CreateCloudProvider exports createCloudProvider for testing.
+var CreateCloudProvider = createCloudProvider
+
+// TestProviderMapData is an alias for providerMapData for testing.
+type TestProviderMapData = providerMapData
+
+// SetLegacyProviders sets the legacy Providers field for testing.
+func (s *ProviderMapService) SetLegacyProviders(provs map[string]Provider) {
+	s.Providers = provs
+}
+
+// Provider is a type alias for providers.Provider to allow mock providers in tests.
+type Provider = providers.Provider
+
+// MockProvider is a minimal implementation of providers.Provider for testing.
+type MockProvider struct {
+	ModelMappingVal    map[string]string
+	NameVal            string
+	BaseURLVal         string
+	OwnerVal           string
+	StreamingTypeVal   string
+	StreamingVal       bool
+	TransparentAuthVal bool
+	BodyTransformVal   bool
+}
+
+func (m *MockProvider) Name() string    { return m.NameVal }
+func (m *MockProvider) BaseURL() string { return m.BaseURLVal }
+func (m *MockProvider) Owner() string   { return m.OwnerVal }
+func (m *MockProvider) Authenticate(_ *http.Request, _ string) error {
+	return nil
+}
+func (m *MockProvider) ForwardHeaders(h http.Header) http.Header { return h }
+func (m *MockProvider) SupportsStreaming() bool                  { return m.StreamingVal }
+func (m *MockProvider) SupportsTransparentAuth() bool            { return m.TransparentAuthVal }
+func (m *MockProvider) ListModels() []providers.Model            { return nil }
+func (m *MockProvider) GetModelMapping() map[string]string       { return m.ModelMappingVal }
+func (m *MockProvider) MapModel(model string) string {
+	if m, ok := m.ModelMappingVal[model]; ok {
+		return m
+	}
+	return model
+}
+func (m *MockProvider) TransformRequest(
+	body []byte, endpoint string,
+) (transformedBody []byte, transformedEndpoint string, err error) {
+	return body, endpoint, nil
+}
+func (m *MockProvider) TransformResponse(_ *http.Response, _ http.ResponseWriter) error {
+	return nil
+}
+func (m *MockProvider) RequiresBodyTransform() bool { return m.BodyTransformVal }
+func (m *MockProvider) StreamingContentType() string {
+	if m.StreamingTypeVal != "" {
+		return m.StreamingTypeVal
+	}
+	return "text/event-stream"
 }

--- a/internal/di/provider_factory_test.go
+++ b/internal/di/provider_factory_test.go
@@ -82,6 +82,51 @@ func newMockProvider() *di.MockProvider {
 	}
 }
 
+// runCloudProviderValidation runs a table of cloud-provider validation cases
+// against di.CreateCloudProvider. For an expected error, it asserts the exact
+// error message. For a valid config (wantErr == ""), it tolerates credential
+// failures but asserts the error is NOT a validation error by checking that
+// none of forbiddenSubstrings appear in the error message.
+func runCloudProviderValidation[T any](
+	t *testing.T,
+	tests []T,
+	getName func(T) string,
+	getCfg func(T) config.ProviderConfig,
+	getWantErr func(T) string,
+	forbiddenSubstrings []string,
+) {
+	t.Helper()
+	for _, testCase := range tests {
+		t.Run(getName(testCase), func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			cfg := getCfg(testCase)
+			wantErr := getWantErr(testCase)
+
+			prov, err := di.CreateCloudProvider(ctx, &cfg)
+
+			if wantErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, wantErr, err.Error())
+				assert.Nil(t, prov)
+				return
+			}
+			// Valid config may still fail without cloud credentials but shouldn't fail
+			// validation. Either the provider is returned, or the error is NOT a
+			// validation error (ErrUnknownProviderType / required-field error).
+			if err == nil {
+				assert.NotNil(t, prov, "expected provider when no error returned")
+				return
+			}
+			assert.NotErrorIs(t, err, di.ErrUnknownProviderType)
+			for _, forbidden := range forbiddenSubstrings {
+				assert.NotContains(t, err.Error(), forbidden)
+			}
+		})
+	}
+}
+
 func TestCreateCloudProviderBedrockValidation(t *testing.T) {
 	t.Parallel()
 
@@ -106,31 +151,32 @@ func TestCreateCloudProviderBedrockValidation(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-
-			prov, err := di.CreateCloudProvider(ctx, &testCase.cfg)
-
-			if testCase.wantErr != "" {
-				assert.Error(t, err)
-				assert.Equal(t, testCase.wantErr, err.Error())
-				assert.Nil(t, prov)
-				return
-			}
-			// Valid config may still fail without AWS credentials but shouldn't fail
-			// validation. Either the provider is returned, or the error is NOT a
-			// validation error (ErrUnknownProviderType / required-field error).
-			if err == nil {
-				assert.NotNil(t, prov, "expected provider when no error returned")
-			} else {
-				assert.NotErrorIs(t, err, di.ErrUnknownProviderType)
-				assert.NotContains(t, err.Error(), "region is required")
-				assert.NotContains(t, err.Error(), "required for bedrock provider")
-			}
-		})
-	}
+	runCloudProviderValidation(
+		t,
+		tests,
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) string {
+			return tc.name
+		},
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) config.ProviderConfig {
+			return tc.cfg
+		},
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) string {
+			return tc.wantErr
+		},
+		[]string{"region is required", "required for bedrock provider"},
+	)
 }
 
 func TestCreateCloudProviderVertexValidation(t *testing.T) {
@@ -167,32 +213,32 @@ func TestCreateCloudProviderVertexValidation(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-
-			prov, err := di.CreateCloudProvider(ctx, &testCase.cfg)
-
-			if testCase.wantErr != "" {
-				assert.Error(t, err)
-				assert.Equal(t, testCase.wantErr, err.Error())
-				assert.Nil(t, prov)
-				return
-			}
-			// Valid config may still fail without GCP credentials but shouldn't fail
-			// validation. Either the provider is returned, or the error is NOT a
-			// validation error (ErrUnknownProviderType / required-field error).
-			if err == nil {
-				assert.NotNil(t, prov, "expected provider when no error returned")
-			} else {
-				assert.NotErrorIs(t, err, di.ErrUnknownProviderType)
-				assert.NotContains(t, err.Error(), "project ID is required")
-				assert.NotContains(t, err.Error(), "region is required")
-				assert.NotContains(t, err.Error(), "required for vertex provider")
-			}
-		})
-	}
+	runCloudProviderValidation(
+		t,
+		tests,
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) string {
+			return tc.name
+		},
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) config.ProviderConfig {
+			return tc.cfg
+		},
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) string {
+			return tc.wantErr
+		},
+		[]string{"project ID is required", "region is required", "required for vertex provider"},
+	)
 }
 
 func TestCreateCloudProviderAzureValidation(t *testing.T) {
@@ -219,31 +265,32 @@ func TestCreateCloudProviderAzureValidation(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-
-			prov, err := di.CreateCloudProvider(ctx, &testCase.cfg)
-
-			if testCase.wantErr != "" {
-				assert.Error(t, err)
-				assert.Equal(t, testCase.wantErr, err.Error())
-				assert.Nil(t, prov)
-				return
-			}
-			// Valid config may still fail without Azure credentials but shouldn't fail
-			// validation. Either the provider is returned, or the error is NOT a
-			// validation error (ErrUnknownProviderType / required-field error).
-			if err == nil {
-				assert.NotNil(t, prov, "expected provider when no error returned")
-			} else {
-				assert.NotErrorIs(t, err, di.ErrUnknownProviderType)
-				assert.NotContains(t, err.Error(), "resource name is required")
-				assert.NotContains(t, err.Error(), "required for azure provider")
-			}
-		})
-	}
+	runCloudProviderValidation(
+		t,
+		tests,
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) string {
+			return tc.name
+		},
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) config.ProviderConfig {
+			return tc.cfg
+		},
+		func(tc struct {
+			name    string
+			wantErr string
+			cfg     config.ProviderConfig
+		}) string {
+			return tc.wantErr
+		},
+		[]string{"resource name is required", "required for azure provider"},
+	)
 }
 
 func TestCreateCloudProviderUnknownType(t *testing.T) {

--- a/internal/di/provider_factory_test.go
+++ b/internal/di/provider_factory_test.go
@@ -1,0 +1,401 @@
+package di_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/omarluq/cc-relay/internal/config"
+	"github.com/omarluq/cc-relay/internal/di"
+	"github.com/stretchr/testify/assert"
+)
+
+// baseBedrockConfig returns a fully initialized ProviderConfig with bedrock type.
+func baseBedrockConfig(name, region string) config.ProviderConfig {
+	return config.ProviderConfig{
+		ModelMapping:       map[string]string{},
+		AWSRegion:          region,
+		GCPProjectID:       "",
+		AzureAPIVersion:    "",
+		Name:               name,
+		Type:               di.ProviderTypeBedrock,
+		BaseURL:            "",
+		AzureDeploymentID:  "",
+		AWSAccessKeyID:     "",
+		AzureResourceName:  "",
+		AWSSecretAccessKey: "",
+		GCPRegion:          "",
+		Models:             nil,
+		Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
+		Keys:               nil,
+		Enabled:            true,
+	}
+}
+
+// baseVertexConfig returns a fully initialized ProviderConfig with vertex type.
+//nolint:unparam // name receives "test-vertex" in tests but parameter kept for API consistency
+func baseVertexConfig(name, project, region string) config.ProviderConfig {
+	return config.ProviderConfig{
+		ModelMapping:       map[string]string{},
+		AWSRegion:          "",
+		GCPProjectID:       project,
+		AzureAPIVersion:    "",
+		Name:               name,
+		Type:               di.ProviderTypeVertex,
+		BaseURL:            "",
+		AzureDeploymentID:  "",
+		AWSAccessKeyID:     "",
+		AzureResourceName:  "",
+		AWSSecretAccessKey: "",
+		GCPRegion:          region,
+		Models:             nil,
+		Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
+		Keys:               nil,
+		Enabled:            true,
+	}
+}
+
+// baseAzureConfig returns a fully initialized ProviderConfig with azure type.
+func baseAzureConfig(name, resource, deployment, apiVersion string) config.ProviderConfig {
+	return config.ProviderConfig{
+		ModelMapping:       map[string]string{},
+		AWSRegion:          "",
+		GCPProjectID:       "",
+		AzureAPIVersion:    apiVersion,
+		Name:               name,
+		Type:               di.ProviderTypeAzure,
+		BaseURL:            "",
+		AzureDeploymentID:  deployment,
+		AWSAccessKeyID:     "",
+		AzureResourceName:  resource,
+		AWSSecretAccessKey: "",
+		GCPRegion:          "",
+		Models:             nil,
+		Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
+		Keys:               nil,
+		Enabled:            true,
+	}
+}
+
+// newEmptyProviderMapData returns a fully initialized empty providerMapData.
+func newEmptyProviderMapData() *di.TestProviderMapData {
+	return &di.TestProviderMapData{
+		PrimaryProvider: nil,
+		Providers:       map[string]di.Provider{},
+		PrimaryKey:      "",
+		AllProviders:    nil,
+	}
+}
+
+// newMockProvider returns a fully initialized MockProvider.
+func newMockProvider() *di.MockProvider {
+	return &di.MockProvider{
+		ModelMappingVal:    map[string]string{},
+		NameVal:            "",
+		BaseURLVal:         "",
+		OwnerVal:           "",
+		StreamingTypeVal:   "",
+		StreamingVal:       false,
+		TransparentAuthVal: false,
+		BodyTransformVal:   false,
+	}
+}
+
+func TestCreateCloudProviderBedrockValidation(t *testing.T) {
+	t.Parallel()
+
+	validCfg := baseBedrockConfig("test-bedrock", "us-east-1")
+	validCfg.Models = []string{"claude-3-5-sonnet"}
+	validCfg.ModelMapping = map[string]string{"anthropic": "claude-3-5-sonnet"}
+
+	tests := []struct {
+		name    string
+		wantErr string
+		cfg     config.ProviderConfig
+	}{
+		{
+			name:    "missing AWS region",
+			cfg:     baseBedrockConfig("test-bedrock", ""),
+			wantErr: "bedrock provider test-bedrock: config: aws_region required for bedrock provider",
+		},
+		{
+			name:    "valid bedrock config",
+			cfg:     validCfg,
+			wantErr: "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			prov, err := di.CreateCloudProvider(ctx, &testCase.cfg)
+
+			if testCase.wantErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, testCase.wantErr, err.Error())
+				assert.Nil(t, prov)
+				return
+			}
+			// Valid config may still fail without AWS credentials but shouldn't fail validation.
+			if err != nil {
+				assert.NotContains(t, err.Error(), "region is required")
+			}
+		})
+	}
+}
+
+func TestCreateCloudProviderVertexValidation(t *testing.T) {
+	t.Parallel()
+
+	validCfg := baseVertexConfig("test-vertex", "test-project", "us-central1")
+	validCfg.Models = []string{"claude-3-5-sonnet"}
+	validCfg.ModelMapping = map[string]string{"anthropic": "claude-3-5-sonnet"}
+
+	tests := []struct {
+		name    string
+		wantErr string
+		cfg     config.ProviderConfig
+	}{
+		{
+			name:    "missing GCP project ID",
+			cfg:     baseVertexConfig("test-vertex", "", "us-central1"),
+			wantErr: "vertex provider test-vertex: config: gcp_project_id required for vertex provider",
+		},
+		{
+			name:    "missing GCP region",
+			cfg:     baseVertexConfig("test-vertex", "test-project", ""),
+			wantErr: "vertex provider test-vertex: config: gcp_region required for vertex provider",
+		},
+		{
+			name:    "missing both GCP project ID and region",
+			cfg:     baseVertexConfig("test-vertex", "", ""),
+			wantErr: "vertex provider test-vertex: config: gcp_project_id required for vertex provider",
+		},
+		{
+			name:    "valid vertex config",
+			cfg:     validCfg,
+			wantErr: "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			prov, err := di.CreateCloudProvider(ctx, &testCase.cfg)
+
+			if testCase.wantErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, testCase.wantErr, err.Error())
+				assert.Nil(t, prov)
+				return
+			}
+			if err != nil {
+				assert.NotContains(t, err.Error(), "project ID is required")
+				assert.NotContains(t, err.Error(), "region is required")
+			}
+		})
+	}
+}
+
+func TestCreateCloudProviderAzureValidation(t *testing.T) {
+	t.Parallel()
+
+	validCfg := baseAzureConfig("test-azure", "test-resource", "test-deployment", "2024-02-01")
+	validCfg.Models = []string{"claude-3-5-sonnet"}
+	validCfg.ModelMapping = map[string]string{"anthropic": "claude-3-5-sonnet"}
+
+	tests := []struct {
+		name    string
+		wantErr string
+		cfg     config.ProviderConfig
+	}{
+		{
+			name:    "missing Azure resource name",
+			cfg:     baseAzureConfig("test-azure", "", "test-deployment", "2024-02-01"),
+			wantErr: "azure provider test-azure: config: azure_resource_name required for azure provider",
+		},
+		{
+			name:    "valid azure config",
+			cfg:     validCfg,
+			wantErr: "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			prov, err := di.CreateCloudProvider(ctx, &testCase.cfg)
+
+			if testCase.wantErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, testCase.wantErr, err.Error())
+				assert.Nil(t, prov)
+				return
+			}
+			if err != nil {
+				assert.NotContains(t, err.Error(), "resource name is required")
+			}
+		})
+	}
+}
+
+func TestCreateCloudProviderUnknownType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := config.ProviderConfig{
+		ModelMapping:       map[string]string{},
+		AWSRegion:          "",
+		GCPProjectID:       "",
+		AzureAPIVersion:    "",
+		Name:               "test-unknown",
+		Type:               "unknown-type",
+		BaseURL:            "",
+		AzureDeploymentID:  "",
+		AWSAccessKeyID:     "",
+		AzureResourceName:  "",
+		AWSSecretAccessKey: "",
+		GCPRegion:          "",
+		Models:             nil,
+		Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
+		Keys:               nil,
+		Enabled:            true,
+	}
+
+	prov, err := di.CreateCloudProvider(ctx, &cfg)
+
+	assert.ErrorIs(t, err, di.ErrUnknownProviderType)
+	assert.Nil(t, prov)
+}
+
+func TestCreateCloudProviderNonCloudType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// createCloudProvider should return ErrUnknownProviderType for non-cloud types
+	nonCloudTypes := []string{
+		di.ProviderTypeAnthropic,
+		di.ProviderTypeZAI,
+		di.ProviderTypeMiniMax,
+		di.ProviderTypeOllama,
+	}
+
+	for _, pType := range nonCloudTypes {
+		t.Run(pType, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.ProviderConfig{
+				ModelMapping:       map[string]string{},
+				AWSRegion:          "",
+				GCPProjectID:       "",
+				AzureAPIVersion:    "",
+				Name:               "test-" + pType,
+				Type:               pType,
+				BaseURL:            "https://api.example.com",
+				AzureDeploymentID:  "",
+				AWSAccessKeyID:     "",
+				AzureResourceName:  "",
+				AWSSecretAccessKey: "",
+				GCPRegion:          "",
+				Models:             nil,
+				Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
+				Keys:               nil,
+				Enabled:            true,
+			}
+
+			prov, err := di.CreateCloudProvider(ctx, &cfg)
+
+			assert.ErrorIs(t, err, di.ErrUnknownProviderType)
+			assert.Nil(t, prov)
+		})
+	}
+}
+
+func TestGetProvider(t *testing.T) {
+	t.Parallel()
+
+	mockProvider := newMockProvider()
+
+	t.Run("found provider returns provider and true", func(t *testing.T) {
+		t.Parallel()
+		svc := di.NewProviderMapServiceWithConfigService(di.NewConfigServiceUninitialized())
+
+		data := newEmptyProviderMapData()
+		data.Providers = map[string]di.Provider{
+			"test-provider": mockProvider,
+		}
+		svc.StoreProviderMapData(data)
+
+		prov, ok := svc.GetProvider("test-provider")
+
+		assert.Same(t, mockProvider, prov)
+		assert.True(t, ok)
+	})
+
+	t.Run("not found provider returns nil and false", func(t *testing.T) {
+		t.Parallel()
+		svc := di.NewProviderMapServiceWithConfigService(di.NewConfigServiceUninitialized())
+
+		data := newEmptyProviderMapData()
+		data.Providers = map[string]di.Provider{
+			"other-provider": mockProvider,
+		}
+		svc.StoreProviderMapData(data)
+
+		prov, ok := svc.GetProvider("non-existent")
+
+		assert.Nil(t, prov)
+		assert.False(t, ok)
+	})
+
+	t.Run("nil providers map returns nil and false", func(t *testing.T) {
+		t.Parallel()
+		svc := di.NewProviderMapServiceWithConfigService(di.NewConfigServiceUninitialized())
+
+		data := newEmptyProviderMapData()
+		data.Providers = nil
+		svc.StoreProviderMapData(data)
+
+		prov, ok := svc.GetProvider("any-provider")
+
+		assert.Nil(t, prov)
+		assert.False(t, ok)
+	})
+
+	t.Run("empty providers map returns nil and false", func(t *testing.T) {
+		t.Parallel()
+		svc := di.NewProviderMapServiceWithConfigService(di.NewConfigServiceUninitialized())
+
+		svc.StoreProviderMapData(newEmptyProviderMapData())
+
+		prov, ok := svc.GetProvider("any-provider")
+
+		assert.Nil(t, prov)
+		assert.False(t, ok)
+	})
+}
+
+func TestGetProviderLegacyFallback(t *testing.T) {
+	t.Parallel()
+
+	mockProvider := newMockProvider()
+
+	t.Run("uses legacy field when atomic data is nil", func(t *testing.T) {
+		t.Parallel()
+		svc := di.NewProviderMapServiceWithConfigService(di.NewConfigServiceUninitialized())
+
+		// Don't call StoreProviderMapData, so atomic data remains nil.
+		svc.SetLegacyProviders(map[string]di.Provider{
+			"legacy-provider": mockProvider,
+		})
+
+		prov, ok := svc.GetProvider("legacy-provider")
+
+		assert.Equal(t, mockProvider, prov)
+		assert.True(t, ok)
+	})
+}

--- a/internal/di/provider_factory_test.go
+++ b/internal/di/provider_factory_test.go
@@ -41,9 +41,8 @@ func baseBedrockConfig(name, region string) config.ProviderConfig {
 }
 
 // baseVertexConfig returns a fully initialized ProviderConfig with vertex type.
-//nolint:unparam // name receives "test-vertex" in tests but parameter kept for API consistency
-func baseVertexConfig(name, project, region string) config.ProviderConfig {
-	cfg := baseProviderConfig(name, di.ProviderTypeVertex)
+func baseVertexConfig(project, region string) config.ProviderConfig {
+	cfg := baseProviderConfig("test-vertex", di.ProviderTypeVertex)
 	cfg.GCPProjectID = project
 	cfg.GCPRegion = region
 	return cfg
@@ -82,33 +81,39 @@ func newMockProvider() *di.MockProvider {
 	}
 }
 
+// cloudProviderValidationCase is the common table-row type shared across all
+// cloud-provider validation tests. Using a named struct (rather than an
+// anonymous one per test) lets the runner accept the slice directly without
+// per-test getter callbacks.
+type cloudProviderValidationCase struct {
+	name    string
+	wantErr string
+	cfg     config.ProviderConfig
+}
+
 // runCloudProviderValidation runs a table of cloud-provider validation cases
 // against di.CreateCloudProvider. For an expected error, it asserts the exact
 // error message. For a valid config (wantErr == ""), it tolerates credential
 // failures but asserts the error is NOT a validation error by checking that
 // none of forbiddenSubstrings appear in the error message.
-func runCloudProviderValidation[T any](
+func runCloudProviderValidation(
 	t *testing.T,
-	tests []T,
-	getName func(T) string,
-	getCfg func(T) config.ProviderConfig,
-	getWantErr func(T) string,
+	tests []cloudProviderValidationCase,
 	forbiddenSubstrings []string,
 ) {
 	t.Helper()
-	for _, testCase := range tests {
-		t.Run(getName(testCase), func(t *testing.T) {
+	for i := range tests {
+		testCase := &tests[i]
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
 
-			cfg := getCfg(testCase)
-			wantErr := getWantErr(testCase)
-
+			cfg := testCase.cfg
 			prov, err := di.CreateCloudProvider(ctx, &cfg)
 
-			if wantErr != "" {
+			if testCase.wantErr != "" {
 				assert.Error(t, err)
-				assert.Equal(t, wantErr, err.Error())
+				assert.Equal(t, testCase.wantErr, err.Error())
 				assert.Nil(t, prov)
 				return
 			}
@@ -127,204 +132,112 @@ func runCloudProviderValidation[T any](
 	}
 }
 
+// withValidModels attaches a sample model and mapping to cfg in place.
+// Used to promote a base provider config into a "valid" one for validation tests.
+func withValidModels(cfg *config.ProviderConfig) {
+	cfg.Models = []string{"claude-3-5-sonnet"}
+	cfg.ModelMapping = map[string]string{"anthropic": "claude-3-5-sonnet"}
+}
+
 func TestCreateCloudProviderBedrockValidation(t *testing.T) {
 	t.Parallel()
 
-	validCfg := baseBedrockConfig("test-bedrock", "us-east-1")
-	validCfg.Models = []string{"claude-3-5-sonnet"}
-	validCfg.ModelMapping = map[string]string{"anthropic": "claude-3-5-sonnet"}
-
-	tests := []struct {
-		name    string
-		wantErr string
-		cfg     config.ProviderConfig
-	}{
+	tests := []cloudProviderValidationCase{
 		{
 			name:    "missing AWS region",
 			cfg:     baseBedrockConfig("test-bedrock", ""),
 			wantErr: "bedrock provider test-bedrock: config: aws_region required for bedrock provider",
 		},
 		{
-			name:    "valid bedrock config",
-			cfg:     validCfg,
+			name: "valid bedrock config",
+			cfg: func() config.ProviderConfig {
+				c := baseBedrockConfig("test-bedrock", "us-east-1")
+				withValidModels(&c)
+				return c
+			}(),
 			wantErr: "",
 		},
 	}
 
-	runCloudProviderValidation(
-		t,
-		tests,
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) string {
-			return tc.name
-		},
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) config.ProviderConfig {
-			return tc.cfg
-		},
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) string {
-			return tc.wantErr
-		},
-		[]string{"region is required", "required for bedrock provider"},
-	)
+	runCloudProviderValidation(t, tests, []string{"region is required", "required for bedrock provider"})
 }
 
 func TestCreateCloudProviderVertexValidation(t *testing.T) {
 	t.Parallel()
 
-	validCfg := baseVertexConfig("test-vertex", "test-project", "us-central1")
-	validCfg.Models = []string{"claude-3-5-sonnet"}
-	validCfg.ModelMapping = map[string]string{"anthropic": "claude-3-5-sonnet"}
-
-	tests := []struct {
-		name    string
-		wantErr string
-		cfg     config.ProviderConfig
-	}{
+	tests := []cloudProviderValidationCase{
 		{
 			name:    "missing GCP project ID",
-			cfg:     baseVertexConfig("test-vertex", "", "us-central1"),
+			cfg:     baseVertexConfig("", "us-central1"),
 			wantErr: "vertex provider test-vertex: config: gcp_project_id required for vertex provider",
 		},
 		{
 			name:    "missing GCP region",
-			cfg:     baseVertexConfig("test-vertex", "test-project", ""),
+			cfg:     baseVertexConfig("test-project", ""),
 			wantErr: "vertex provider test-vertex: config: gcp_region required for vertex provider",
 		},
 		{
 			name:    "missing both GCP project ID and region",
-			cfg:     baseVertexConfig("test-vertex", "", ""),
+			cfg:     baseVertexConfig("", ""),
 			wantErr: "vertex provider test-vertex: config: gcp_project_id required for vertex provider",
 		},
 		{
-			name:    "valid vertex config",
-			cfg:     validCfg,
+			name: "valid vertex config",
+			cfg: func() config.ProviderConfig {
+				c := baseVertexConfig("test-project", "us-central1")
+				withValidModels(&c)
+				return c
+			}(),
 			wantErr: "",
 		},
 	}
 
-	runCloudProviderValidation(
-		t,
-		tests,
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) string {
-			return tc.name
-		},
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) config.ProviderConfig {
-			return tc.cfg
-		},
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) string {
-			return tc.wantErr
-		},
-		[]string{"project ID is required", "region is required", "required for vertex provider"},
-	)
+	runCloudProviderValidation(t, tests, []string{
+		"project ID is required", "region is required", "required for vertex provider",
+	})
 }
 
 func TestCreateCloudProviderAzureValidation(t *testing.T) {
 	t.Parallel()
 
-	validCfg := baseAzureConfig("test-azure", "test-resource", "test-deployment", "2024-02-01")
-	validCfg.Models = []string{"claude-3-5-sonnet"}
-	validCfg.ModelMapping = map[string]string{"anthropic": "claude-3-5-sonnet"}
-
-	tests := []struct {
-		name    string
-		wantErr string
-		cfg     config.ProviderConfig
-	}{
+	tests := []cloudProviderValidationCase{
 		{
 			name:    "missing Azure resource name",
 			cfg:     baseAzureConfig("test-azure", "", "test-deployment", "2024-02-01"),
 			wantErr: "azure provider test-azure: config: azure_resource_name required for azure provider",
 		},
 		{
-			name:    "valid azure config",
-			cfg:     validCfg,
+			name: "valid azure config",
+			cfg: func() config.ProviderConfig {
+				c := baseAzureConfig("test-azure", "test-resource", "test-deployment", "2024-02-01")
+				withValidModels(&c)
+				return c
+			}(),
 			wantErr: "",
 		},
 	}
 
-	runCloudProviderValidation(
-		t,
-		tests,
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) string {
-			return tc.name
-		},
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) config.ProviderConfig {
-			return tc.cfg
-		},
-		func(tc struct {
-			name    string
-			wantErr string
-			cfg     config.ProviderConfig
-		}) string {
-			return tc.wantErr
-		},
-		[]string{"resource name is required", "required for azure provider"},
-	)
+	runCloudProviderValidation(t, tests, []string{"resource name is required", "required for azure provider"})
 }
 
-func TestCreateCloudProviderUnknownType(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	cfg := config.ProviderConfig{
-		ModelMapping:       map[string]string{},
-		AWSRegion:          "",
-		GCPProjectID:       "",
-		AzureAPIVersion:    "",
-		Name:               "test-unknown",
-		Type:               "unknown-type",
-		BaseURL:            "",
-		AzureDeploymentID:  "",
-		AWSAccessKeyID:     "",
-		AzureResourceName:  "",
-		AWSSecretAccessKey: "",
-		GCPRegion:          "",
-		Models:             nil,
-		Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
-		Keys:               nil,
-		Enabled:            true,
-	}
-
-	prov, err := di.CreateCloudProvider(ctx, &cfg)
-
+// assertUnknownProviderType asserts that CreateCloudProvider returns
+// ErrUnknownProviderType for the given config. Shared between the
+// Unknown/NonCloud tests to keep assertion shape identical.
+func assertUnknownProviderType(t *testing.T, cfg *config.ProviderConfig) {
+	t.Helper()
+	prov, err := di.CreateCloudProvider(context.Background(), cfg)
 	assert.ErrorIs(t, err, di.ErrUnknownProviderType)
 	assert.Nil(t, prov)
 }
 
+func TestCreateCloudProviderUnknownType(t *testing.T) {
+	t.Parallel()
+	cfg := baseProviderConfig("test-unknown", "unknown-type")
+	assertUnknownProviderType(t, &cfg)
+}
+
 func TestCreateCloudProviderNonCloudType(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// createCloudProvider should return ErrUnknownProviderType for non-cloud types
 	nonCloudTypes := []string{
@@ -337,29 +250,9 @@ func TestCreateCloudProviderNonCloudType(t *testing.T) {
 	for _, pType := range nonCloudTypes {
 		t.Run(pType, func(t *testing.T) {
 			t.Parallel()
-			cfg := config.ProviderConfig{
-				ModelMapping:       map[string]string{},
-				AWSRegion:          "",
-				GCPProjectID:       "",
-				AzureAPIVersion:    "",
-				Name:               "test-" + pType,
-				Type:               pType,
-				BaseURL:            "https://api.example.com",
-				AzureDeploymentID:  "",
-				AWSAccessKeyID:     "",
-				AzureResourceName:  "",
-				AWSSecretAccessKey: "",
-				GCPRegion:          "",
-				Models:             nil,
-				Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
-				Keys:               nil,
-				Enabled:            true,
-			}
-
-			prov, err := di.CreateCloudProvider(ctx, &cfg)
-
-			assert.ErrorIs(t, err, di.ErrUnknownProviderType)
-			assert.Nil(t, prov)
+			cfg := baseProviderConfig("test-"+pType, pType)
+			cfg.BaseURL = "https://api.example.com"
+			assertUnknownProviderType(t, &cfg)
 		})
 	}
 }

--- a/internal/di/provider_factory_test.go
+++ b/internal/di/provider_factory_test.go
@@ -9,15 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// baseBedrockConfig returns a fully initialized ProviderConfig with bedrock type.
-func baseBedrockConfig(name, region string) config.ProviderConfig {
+// baseProviderConfig returns a fully zero-initialized ProviderConfig for the
+// given name and type. Specialized helpers layer provider-specific fields on
+// top of this base to avoid repeating the full struct literal.
+func baseProviderConfig(name, pType string) config.ProviderConfig {
 	return config.ProviderConfig{
 		ModelMapping:       map[string]string{},
-		AWSRegion:          region,
+		AWSRegion:          "",
 		GCPProjectID:       "",
 		AzureAPIVersion:    "",
 		Name:               name,
-		Type:               di.ProviderTypeBedrock,
+		Type:               pType,
 		BaseURL:            "",
 		AzureDeploymentID:  "",
 		AWSAccessKeyID:     "",
@@ -29,51 +31,31 @@ func baseBedrockConfig(name, region string) config.ProviderConfig {
 		Keys:               nil,
 		Enabled:            true,
 	}
+}
+
+// baseBedrockConfig returns a fully initialized ProviderConfig with bedrock type.
+func baseBedrockConfig(name, region string) config.ProviderConfig {
+	cfg := baseProviderConfig(name, di.ProviderTypeBedrock)
+	cfg.AWSRegion = region
+	return cfg
 }
 
 // baseVertexConfig returns a fully initialized ProviderConfig with vertex type.
 //nolint:unparam // name receives "test-vertex" in tests but parameter kept for API consistency
 func baseVertexConfig(name, project, region string) config.ProviderConfig {
-	return config.ProviderConfig{
-		ModelMapping:       map[string]string{},
-		AWSRegion:          "",
-		GCPProjectID:       project,
-		AzureAPIVersion:    "",
-		Name:               name,
-		Type:               di.ProviderTypeVertex,
-		BaseURL:            "",
-		AzureDeploymentID:  "",
-		AWSAccessKeyID:     "",
-		AzureResourceName:  "",
-		AWSSecretAccessKey: "",
-		GCPRegion:          region,
-		Models:             nil,
-		Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
-		Keys:               nil,
-		Enabled:            true,
-	}
+	cfg := baseProviderConfig(name, di.ProviderTypeVertex)
+	cfg.GCPProjectID = project
+	cfg.GCPRegion = region
+	return cfg
 }
 
 // baseAzureConfig returns a fully initialized ProviderConfig with azure type.
 func baseAzureConfig(name, resource, deployment, apiVersion string) config.ProviderConfig {
-	return config.ProviderConfig{
-		ModelMapping:       map[string]string{},
-		AWSRegion:          "",
-		GCPProjectID:       "",
-		AzureAPIVersion:    apiVersion,
-		Name:               name,
-		Type:               di.ProviderTypeAzure,
-		BaseURL:            "",
-		AzureDeploymentID:  deployment,
-		AWSAccessKeyID:     "",
-		AzureResourceName:  resource,
-		AWSSecretAccessKey: "",
-		GCPRegion:          "",
-		Models:             nil,
-		Pooling:            config.PoolingConfig{Enabled: false, Strategy: ""},
-		Keys:               nil,
-		Enabled:            true,
-	}
+	cfg := baseProviderConfig(name, di.ProviderTypeAzure)
+	cfg.AzureResourceName = resource
+	cfg.AzureDeploymentID = deployment
+	cfg.AzureAPIVersion = apiVersion
+	return cfg
 }
 
 // newEmptyProviderMapData returns a fully initialized empty providerMapData.
@@ -137,9 +119,15 @@ func TestCreateCloudProviderBedrockValidation(t *testing.T) {
 				assert.Nil(t, prov)
 				return
 			}
-			// Valid config may still fail without AWS credentials but shouldn't fail validation.
-			if err != nil {
+			// Valid config may still fail without AWS credentials but shouldn't fail
+			// validation. Either the provider is returned, or the error is NOT a
+			// validation error (ErrUnknownProviderType / required-field error).
+			if err == nil {
+				assert.NotNil(t, prov, "expected provider when no error returned")
+			} else {
+				assert.NotErrorIs(t, err, di.ErrUnknownProviderType)
 				assert.NotContains(t, err.Error(), "region is required")
+				assert.NotContains(t, err.Error(), "required for bedrock provider")
 			}
 		})
 	}
@@ -192,9 +180,16 @@ func TestCreateCloudProviderVertexValidation(t *testing.T) {
 				assert.Nil(t, prov)
 				return
 			}
-			if err != nil {
+			// Valid config may still fail without GCP credentials but shouldn't fail
+			// validation. Either the provider is returned, or the error is NOT a
+			// validation error (ErrUnknownProviderType / required-field error).
+			if err == nil {
+				assert.NotNil(t, prov, "expected provider when no error returned")
+			} else {
+				assert.NotErrorIs(t, err, di.ErrUnknownProviderType)
 				assert.NotContains(t, err.Error(), "project ID is required")
 				assert.NotContains(t, err.Error(), "region is required")
+				assert.NotContains(t, err.Error(), "required for vertex provider")
 			}
 		})
 	}
@@ -237,8 +232,15 @@ func TestCreateCloudProviderAzureValidation(t *testing.T) {
 				assert.Nil(t, prov)
 				return
 			}
-			if err != nil {
+			// Valid config may still fail without Azure credentials but shouldn't fail
+			// validation. Either the provider is returned, or the error is NOT a
+			// validation error (ErrUnknownProviderType / required-field error).
+			if err == nil {
+				assert.NotNil(t, prov, "expected provider when no error returned")
+			} else {
+				assert.NotErrorIs(t, err, di.ErrUnknownProviderType)
 				assert.NotContains(t, err.Error(), "resource name is required")
+				assert.NotContains(t, err.Error(), "required for azure provider")
 			}
 		})
 	}

--- a/internal/health/tracker_test.go
+++ b/internal/health/tracker_test.go
@@ -274,3 +274,45 @@ func TestTrackerConcurrentAccess(t *testing.T) {
 		t.Errorf("expected 1 provider in states, got %d", len(states))
 	}
 }
+
+func TestTrackerResetClearsCircuitsAndAppliesNewConfig(t *testing.T) {
+	t.Parallel()
+	logger := zerolog.Nop()
+	initialCfg := health.CircuitBreakerConfig{
+		FailureThreshold: 5,
+		OpenDurationMS:   1000,
+		HalfOpenProbes:   2,
+	}
+
+	tracker := health.NewTracker(initialCfg, &logger)
+
+	// Create two circuits and put them into a non-default state.
+	tracker.RecordFailure("provider-a", errors.New("boom"))
+	tracker.RecordFailure("provider-b", errors.New("boom"))
+
+	before := tracker.AllStates()
+	if len(before) != 2 {
+		t.Fatalf("expected 2 circuits before reset, got %d", len(before))
+	}
+
+	// Reset with a new configuration and a fresh logger.
+	newLogger := zerolog.Nop()
+	newCfg := health.CircuitBreakerConfig{
+		FailureThreshold: 1, // Lower threshold to prove the new config took effect.
+		OpenDurationMS:   30000,
+		HalfOpenProbes:   1,
+	}
+	tracker.Reset(newCfg, &newLogger)
+
+	// Existing circuits should be gone after reset.
+	if states := tracker.AllStates(); len(states) != 0 {
+		t.Errorf("expected 0 circuits after Reset, got %d (%v)", len(states), states)
+	}
+
+	// A newly-created circuit should honor the new threshold (opens after 1 failure).
+	tracker.RecordFailure("provider-c", errors.New("first and only failure"))
+
+	if got := tracker.GetState("provider-c"); got != health.StateOpen {
+		t.Errorf("expected StateOpen after 1 failure with new threshold=1, got %s", got.String())
+	}
+}

--- a/internal/keypool/selector_test.go
+++ b/internal/keypool/selector_test.go
@@ -2,6 +2,7 @@ package keypool_test
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -289,6 +290,34 @@ func TestMarkHealthy(t *testing.T) {
 	assert.True(t, key.Healthy, "Should be healthy after MarkHealthy")
 	assert.Nil(t, key.LastError, "LastError should be nil after MarkHealthy")
 	assert.True(t, key.IsAvailable(), "Should be available after MarkHealthy")
+}
+
+// TestKeyMetadataString verifies the human-readable String() representation.
+func TestKeyMetadataString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fresh key reports full capacity and healthy", func(t *testing.T) {
+		t.Parallel()
+		key := keypool.NewKeyMetadata("sk-test-string-key", 50, 30000, 30000)
+		got := key.String()
+
+		// Must include the 8-char ID, all counters in remaining/limit form, and healthy state.
+		assert.Contains(t, got, fmt.Sprintf("Key[%s]", key.ID),
+			"String() should include the hashed key ID prefix")
+		assert.Contains(t, got, "rpm=50/50", "expected full rpm counter")
+		assert.Contains(t, got, "itpm=30000/30000", "expected full itpm counter")
+		assert.Contains(t, got, "otpm=30000/30000", "expected full otpm counter")
+		assert.Contains(t, got, "healthy=true", "fresh key should be healthy")
+	})
+
+	t.Run("unhealthy key reports healthy=false", func(t *testing.T) {
+		t.Parallel()
+		key := keypool.NewKeyMetadata("sk-unhealthy-key", 50, 30000, 30000)
+		key.MarkUnhealthy(http.ErrServerClosed)
+
+		assert.Contains(t, key.String(), "healthy=false",
+			"MarkUnhealthy should be reflected in String() output")
+	})
 }
 
 // TestLeastLoadedSelector verifies least-loaded selection strategy.

--- a/internal/vinfo/export_test.go
+++ b/internal/vinfo/export_test.go
@@ -1,5 +1,7 @@
 package vinfo
 
+import "runtime/debug"
+
 // FormatDisplayVersion exports formatDisplayVersion for testing.
 var FormatDisplayVersion = formatDisplayVersion
 
@@ -8,3 +10,24 @@ var ShortCommit = shortCommit
 
 // ParseDescribe exports parseDescribe for testing.
 var ParseDescribe = parseDescribe
+
+// ApplySettingsFallback exports applySettingsFallback for testing.
+func ApplySettingsFallback(info *debug.BuildInfo) {
+	applySettingsFallback(info)
+}
+
+// ApplyMainVersionFallback exports applyMainVersionFallback for testing.
+func ApplyMainVersionFallback(info *debug.BuildInfo) {
+	applyMainVersionFallback(info)
+}
+
+// SetVersionVars lets tests mutate the package-level version vars and get a
+// restore function to reset them after the test. Tests that touch these globals
+// MUST avoid t.Parallel() since the variables are package-scoped.
+func SetVersionVars(version, commit, buildDate string) (restore func()) {
+	prevVersion, prevCommit, prevBuildDate := Version, Commit, BuildDate
+	Version, Commit, BuildDate = version, commit, buildDate
+	return func() {
+		Version, Commit, BuildDate = prevVersion, prevCommit, prevBuildDate
+	}
+}

--- a/internal/vinfo/version_test.go
+++ b/internal/vinfo/version_test.go
@@ -1,6 +1,7 @@
 package vinfo_test
 
 import (
+	"runtime/debug"
 	"testing"
 
 	"github.com/omarluq/cc-relay/internal/vinfo"
@@ -14,16 +15,20 @@ func TestVersion(t *testing.T) {
 	}
 }
 
-func TestCommit(t *testing.T) {
-	t.Parallel()
+func TestCommit(t *testing.T) { //nolint:paralleltest // mutates package-level vars
+	restore := vinfo.SetVersionVars("", "test-commit", "")
+	defer restore()
+
 	// Commit should always be non-empty.
 	if vinfo.Commit == "" {
 		t.Error("Commit is empty")
 	}
 }
 
-func TestBuildDate(t *testing.T) {
-	t.Parallel()
+func TestBuildDate(t *testing.T) { //nolint:paralleltest // mutates package-level vars
+	restore := vinfo.SetVersionVars("", "", "test-build-date")
+	defer restore()
+
 	// BuildDate should always be non-empty.
 	if vinfo.BuildDate == "" {
 		t.Error("BuildDate is empty")
@@ -149,5 +154,122 @@ func TestString(t *testing.T) {
 	got := vinfo.String()
 	if got == "" {
 		t.Error("String() returned empty string")
+	}
+}
+
+func TestApplySettingsFallback(t *testing.T) { //nolint:paralleltest // mutates package-level vars
+	restore := vinfo.SetVersionVars("", "", "")
+	defer restore()
+
+	tests := []struct {
+		name          string
+		wantVersion   string
+		wantCommit    string
+		wantBuildDate string
+		settings      []debug.BuildSetting
+	}{
+		{
+			name: "vcs.revision and vcs.time from settings",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abc123def456"},
+				{Key: "vcs.time", Value: "2026-04-18T12:00:00Z"},
+			},
+			wantVersion:   "",
+			wantCommit:    "abc123def456",
+			wantBuildDate: "2026-04-18T12:00:00Z",
+		},
+		{
+			name: "only vcs.revision",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "xyz789"},
+			},
+			wantVersion:   "",
+			wantCommit:    "xyz789",
+			wantBuildDate: "",
+		},
+		{
+			name:          "empty settings",
+			settings:      []debug.BuildSetting{},
+			wantVersion:   "",
+			wantCommit:    "",
+			wantBuildDate: "",
+		},
+		{
+			name: "unrelated keys are ignored",
+			settings: []debug.BuildSetting{
+				{Key: "GOOS", Value: "linux"},
+				{Key: "vcs.revision", Value: "abc123"},
+			},
+			wantVersion:   "",
+			wantCommit:    "abc123",
+			wantBuildDate: "",
+		},
+	}
+
+	for _, testCase := range tests { //nolint:paralleltest // mutates package-level vars
+		t.Run(testCase.name, func(t *testing.T) {
+			restoreInner := vinfo.SetVersionVars("", "", "")
+			defer restoreInner()
+
+			info := &debug.BuildInfo{
+				Settings: testCase.settings,
+			}
+			vinfo.ApplySettingsFallback(info)
+
+			if vinfo.Commit != testCase.wantCommit {
+				t.Errorf("ApplySettingsFallback() Commit = %q, want %q", vinfo.Commit, testCase.wantCommit)
+			}
+			if vinfo.BuildDate != testCase.wantBuildDate {
+				t.Errorf("ApplySettingsFallback() BuildDate = %q, want %q", vinfo.BuildDate, testCase.wantBuildDate)
+			}
+		})
+	}
+}
+
+func TestApplyMainVersionFallback(t *testing.T) { //nolint:paralleltest // mutates package-level vars
+	restore := vinfo.SetVersionVars("", "", "")
+	defer restore()
+
+	tests := []struct {
+		name        string
+		mainVersion string
+		wantVersion string
+	}{
+		{
+			name:        "valid version",
+			mainVersion: "v1.2.3",
+			wantVersion: "v1.2.3",
+		},
+		{
+			name:        "empty version is ignored",
+			mainVersion: "",
+			wantVersion: "",
+		},
+		{
+			name:        "devel marker is ignored",
+			mainVersion: "(devel)",
+			wantVersion: "",
+		},
+		{
+			name:        "version with build metadata",
+			mainVersion: "v1.2.3+meta",
+			wantVersion: "v1.2.3+meta",
+		},
+	}
+
+	for _, testCase := range tests { //nolint:paralleltest // mutates package-level vars
+		t.Run(testCase.name, func(t *testing.T) {
+			restoreInner := vinfo.SetVersionVars("", "", "")
+			defer restoreInner()
+
+			info := &debug.BuildInfo{
+				Main: debug.Module{Path: "test", Version: testCase.mainVersion},
+			}
+			vinfo.ApplyMainVersionFallback(info)
+
+			if vinfo.Version != testCase.wantVersion {
+				t.Errorf("ApplyMainVersionFallback() Version = %q, want %q", vinfo.Version, testCase.wantVersion)
+			}
+		})
 	}
 }

--- a/internal/vinfo/version_test.go
+++ b/internal/vinfo/version_test.go
@@ -222,6 +222,9 @@ func TestApplySettingsFallback(t *testing.T) { //nolint:paralleltest // mutates 
 			if vinfo.BuildDate != testCase.wantBuildDate {
 				t.Errorf("ApplySettingsFallback() BuildDate = %q, want %q", vinfo.BuildDate, testCase.wantBuildDate)
 			}
+			if vinfo.Version != testCase.wantVersion {
+				t.Errorf("ApplySettingsFallback() Version = %q, want %q", vinfo.Version, testCase.wantVersion)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Added comprehensive test coverage for di, health, keypool, and vinfo packages with 684 new lines of tests.