### PR TITLE
test(serve): assert expected error substring on both failure paths

### DIFF
--- a/cmd/cc-relay/serve_test.go
+++ b/cmd/cc-relay/serve_test.go
@@ -124,7 +124,10 @@ func assertServerServiceFails(t *testing.T, configContent, errMsg string) {
 	}
 	_, err = di.Invoke[*di.ServerService](container)
 	if err == nil {
-		t.Errorf("Expected error for %s", errMsg)
+		t.Fatalf("Expected error for %s", errMsg)
+	}
+	if !strings.Contains(err.Error(), errMsg) {
+		t.Fatalf("server-service invocation failed with unexpected error: %v (wanted substring %q)", err, errMsg)
 	}
 }
 
@@ -170,7 +173,7 @@ server:
   listen: "127.0.0.1:18787"
   api_key: "test-key"
 providers: []
-`, "empty providers")
+`, "no enabled provider found")
 }
 
 // validServeConfig is a minimal valid configuration for serve tests.

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -18,8 +18,8 @@ const (
 //
 // Note: this is NOT a technical limit — Go's time.Duration is an int64 of
 // nanoseconds, supporting values up to ~292 years, so 24h ms is comfortably
-// within range. The cap exists to surface user typos (e.g., "60000000" meaning
-// "60s" but mistakenly typed as "60_000_000_000") and to prevent obviously
+// within range. The cap exists to surface user typos (e.g., intending 60_000
+// for "60s" but accidentally typing 60_000_000) and to prevent obviously
 // nonsensical configs from silently producing year-long write timeouts.
 const MaxTimeoutMS = 24 * 60 * 60 * 1000 // 24h in ms = 86_400_000
 


### PR DESCRIPTION
assertServerServiceFails previously only checked the errMsg substring on the early Load/Validate failure path, swallowing any error from di.Invoke[*di.ServerService] without verifying it was the failure we expected. A regression that produced an unrelated invocation error would silently pass.

Tighten the late path: require err != nil and require err.Error() to contain errMsg, fataling otherwise. Update TestRunServeEmptyProviders errMsg to the actual error substring ("no enabled provider found") since the previous descriptive string ("empty providers") never appeared in the runtime error.

Also tweak the MaxTimeoutMS comment example: the prior values were numerically off; replace with a realistic typo shape (intending 60_000 for "60s" but accidentally typing 60_000_000).