### PR TITLE
test(serve): release container in assertServerServiceFails

### DIFF
--- a/cmd/cc-relay/serve_test.go
+++ b/cmd/cc-relay/serve_test.go
@@ -122,6 +122,14 @@ func assertServerServiceFails(t *testing.T, configContent, errMsg string) {
 		}
 		return
 	}
+	// Container creation eagerly starts ConfigService's fsnotify watcher.
+	// Even when we expect downstream invocation to fail, schedule shutdown so
+	// the OS watch handles don't leak across tests.
+	t.Cleanup(func() {
+		if shutdownErr := container.Shutdown(); shutdownErr != nil {
+			t.Logf("container shutdown error: %v", shutdownErr)
+		}
+	})
 	_, err = di.Invoke[*di.ServerService](container)
 	if err == nil {
 		t.Fatalf("Expected error for %s", errMsg)


### PR DESCRIPTION
When di.NewContainer succeeds but ServerService invocation is expected to fail, the helper previously left the container alive for the rest of the test process. ConfigService eagerly starts an fsnotify watcher during container creation, so each such test leaked an OS watch handle across the suite.

Add t.Cleanup with container.Shutdown() right after the successful NewContainer (before invoking ServerService) so the watcher is released on every code path.