### PR TITLE
fix(config): allow empty key on transparent-auth providers (anthropic)

### DIFF
--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -9,10 +9,18 @@ import (
 
 // Provider type constants.
 const (
-	ProviderBedrock = "bedrock"
-	ProviderVertex  = "vertex"
-	ProviderAzure   = "azure"
+	ProviderAnthropic = "anthropic"
+	ProviderBedrock   = "bedrock"
+	ProviderVertex    = "vertex"
+	ProviderAzure     = "azure"
 )
+
+// providerSupportsTransparentAuth returns true if the provider type accepts
+// forwarded client credentials (e.g., Claude Code subscription bearer tokens)
+// in lieu of a configured key. Only Anthropic's API accepts pass-through auth.
+func providerSupportsTransparentAuth(providerType string) bool {
+	return providerType == ProviderAnthropic
+}
 
 // MaxTimeoutMS is an operational/policy upper bound on server.timeout_ms (24h).
 //
@@ -189,7 +197,7 @@ func validateProvider(provider *ProviderConfig, index int, seenNames map[string]
 
 	// Validate keys
 	for keyIdx, key := range provider.Keys {
-		validateProviderKey(&key, provider.Name, keyIdx, errs)
+		validateProviderKey(&key, provider.Name, provider.Type, keyIdx, errs)
 	}
 
 	// Validate pooling strategy if set
@@ -220,7 +228,7 @@ func validateCloudProviderConfig(provider *ProviderConfig, prefix func(string) s
 }
 
 // validateProviderKey validates a single API key configuration.
-func validateProviderKey(keyCfg *KeyConfig, providerName string, index int, errs *ValidationError) {
+func validateProviderKey(keyCfg *KeyConfig, providerName, providerType string, index int, errs *ValidationError) {
 	prefix := func(field string) string {
 		if providerName != "" {
 			return fmt.Sprintf("provider[%s].keys[%d].%s", providerName, index, field)
@@ -228,8 +236,10 @@ func validateProviderKey(keyCfg *KeyConfig, providerName string, index int, errs
 		return fmt.Sprintf("keys[%d].%s", index, field)
 	}
 
-	// Key is required (will be expanded from env var later)
-	if keyCfg.Key == "" {
+	// Key is required, except for providers that support transparent auth
+	// (anthropic): an empty key there means "pass through the client's
+	// subscription bearer token unchanged", which is a valid setup.
+	if keyCfg.Key == "" && !providerSupportsTransparentAuth(providerType) {
 		errs.Addf("%s is required", prefix("key"))
 	}
 
@@ -243,18 +253,26 @@ func validateProviderKey(keyCfg *KeyConfig, providerName string, index int, errs
 		errs.Addf("%s must be >= 0 (got %d)", prefix("weight"), keyCfg.Weight)
 	}
 
-	// Rate limits must be non-negative
-	if keyCfg.RPMLimit < 0 {
-		errs.Addf("%s must be >= 0 (got %d)", prefix("rpm_limit"), keyCfg.RPMLimit)
+	validateKeyRateLimits(keyCfg, prefix, errs)
+}
+
+// validateKeyRateLimits checks that all per-key rate-limit fields are
+// non-negative. Extracted from validateProviderKey to keep cyclomatic
+// complexity manageable.
+func validateKeyRateLimits(keyCfg *KeyConfig, prefix func(string) string, errs *ValidationError) {
+	limits := []struct {
+		name  string
+		value int
+	}{
+		{"rpm_limit", keyCfg.RPMLimit},
+		{"tpm_limit", keyCfg.TPMLimit},
+		{"itpm_limit", keyCfg.ITPMLimit},
+		{"otpm_limit", keyCfg.OTPMLimit},
 	}
-	if keyCfg.TPMLimit < 0 {
-		errs.Addf("%s must be >= 0 (got %d)", prefix("tpm_limit"), keyCfg.TPMLimit)
-	}
-	if keyCfg.ITPMLimit < 0 {
-		errs.Addf("%s must be >= 0 (got %d)", prefix("itpm_limit"), keyCfg.ITPMLimit)
-	}
-	if keyCfg.OTPMLimit < 0 {
-		errs.Addf("%s must be >= 0 (got %d)", prefix("otpm_limit"), keyCfg.OTPMLimit)
+	for _, l := range limits {
+		if l.value < 0 {
+			errs.Addf("%s must be >= 0 (got %d)", prefix(l.name), l.value)
+		}
 	}
 }
 

--- a/internal/config/validator_test.go
+++ b/internal/config/validator_test.go
@@ -581,6 +581,8 @@ func TestValidateMissingKeyValue(t *testing.T) {
 	t.Parallel()
 
 	cfg := configWithSingleProvider(defaultListenAddr)
+	// Use a non-transparent-auth provider so empty keys must be rejected.
+	cfg.Providers[0].Type = "zai"
 
 	key := config.MakeTestKeyConfig("")
 	key.RPMLimit = 60
@@ -593,6 +595,23 @@ func TestValidateMissingKeyValue(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "key") && !strings.Contains(err.Error(), "required") {
 		t.Errorf("Expected key required error, got: %v", err)
+	}
+}
+
+// TestValidateAnthropicAllowsEmptyKey pins the transparent-auth carve-out:
+// for provider type "anthropic", an empty key is legitimate (it means
+// "pass the client's subscription bearer token through unchanged").
+// Regression: validator briefly required keys universally, breaking
+// transparent-auth users with `${ANTHROPIC_API_KEY}` unset.
+func TestValidateAnthropicAllowsEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := configWithSingleProvider(defaultListenAddr)
+	cfg.Providers[0].Type = "anthropic"
+	cfg.Providers[0].Keys = []config.KeyConfig{config.MakeTestKeyConfig("")}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("anthropic with empty key should validate (transparent auth), got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Wiring Validate() into Load() introduced a regression for users running with Anthropic transparent auth — i.e. forwarding a Claude Code subscription bearer token through to api.anthropic.com without a configured API key. The natural config (`key: "${ANTHROPIC_API_KEY}"` expanded to "" when unset, or just `key: ""`) used to work; the validator now rejected it with `provider[anthropic].keys[0].key is required` and the binary refused to start.

Add a transparent-auth carve-out: providers whose type returns true from providerSupportsTransparentAuth (currently only "anthropic") may have empty keys, since an empty key there means "pass the client's bearer token through unchanged". All other provider types (zai, minimax, ollama, bedrock, vertex, azure) still require a real key.

Update TestValidateMissingKeyValue to use type "zai" so the assertion remains meaningful, and add TestValidateAnthropicAllowsEmptyKey to pin the carve-out. Extract validateKeyRateLimits to keep validateProviderKey under the cyclomatic-complexity budget after the new branch.